### PR TITLE
Update README with note about pydevd-pycharm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # async-eval
 
+## Install
+
+```
+poetry install
+```
+
+If not using PyCharm or PyDev, then specify "all-extras" install pydevd-pycharm:
+
+```
+poetry install --all-extras
+```
+
+## Run tests
+
+```
+pytest
+```
+
+## Usage
+
 ```python
 from async_eval import eval
 


### PR DESCRIPTION
If not using PyDev or PyCharm the tests don't run unless pydevd-pycharm is install by specifying --all-extras to poetry install.